### PR TITLE
Corrections / CRE / Sous-titres

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Ce composant apporte toutes les corrections nécessaires aux textes de BG2:EE.
 	- Citoyenne (KPFARM02.CRE).
 	- Usurière (KPLEND02.CRE).
 	- Pleureur (MOURNER5.CRE).
-	- Mage cagoulée (MAGE18A.CRE, MAGE16C.CRE).
+	- Magicienne cagoulée (MAGE18A.CRE, MAGE16C.CRE).
 	- Danseuse (ohbdanc1.CRE, ohbdanc2.CRE).
 	- Assassine (IRETHF05.CRE, ISHTHF02.CRE, PLASS02.CRE).
 	- Soldate de Roenal (KPROEN05.CRE).
@@ -208,6 +208,18 @@ Ce composant apporte toutes les corrections nécessaires aux textes de BG2:EE.
 	- Cuisinière (SCOOK.CRE).
 	- Voyageuse (RERAK03.CRE, RERAK05.CRE, RERAK06.CRE).
 	- Malfaitrice (REBAND04.CRE, TANTUG02.CRE).
+	- Ouvrière (WORKER02.CRE).
+	- Lieutenante magicienne (YAGA02.CRE).
+	- Magicienne (CUTAMMAG.CRE, DGMAG01.CRE, FSMAGE01.CRE, FSMAGE02.CRE, FSMAGE03.CRE, FSMAGE04.CRE, MAGCLE20.CRE, MAGETEST.CRE, SARGRD06.CRE, TANWIZ02.CRE, TOLMAG02.CRE).
+	- Magicienne elfe (DAELF.CRE, DAELF2.CRE).
+	- Magicienne de Yaga-Shura (YSMAGE02.CRE).
+	- Roturier elfe noir (UDCOM01.CRE).
+	- Roturière elfe noire (UDCOM02.CRE).
+	- Ensorceleuse sharrane (ohrshr23.CRE).
+	- Aubergiste (VVSTAND2.CRE).
+	- Roturier (BMTOWN1.CRE, BMTOWN2.CRE, BMTOWN3.CRE, DMTOWN1.CRE, DMTOWN2.CRE, FFCROWD3.CRE, MTOWN1.CRE, MTOWN2.CRE, MTOWN3.CRE, MTOWN4.CRE, SLUMM1.CRE, SLUMM2.CRE, SLUMM3.CRE, SLUMM4.CRE, VVSTAND1.CRE, BDAUD01.CRE, WPCUST1.CRE).
+	- Roturière (BDAUD02.CRE, POSTUL3.CRE, POSTUL5.CRE, SARFEM01.CRE, SARFEM02.CRE, SARFEM03.CRE, SARFEM04.CRE, VVSTAND3.CRE).
+	- Dame (TRFTOW02.CRE).
 	</pre>
 	</details>
 

--- a/correctfrbg2ee/correctfrbg2ee.tp2
+++ b/correctfrbg2ee/correctfrbg2ee.tp2
@@ -436,7 +436,7 @@ BEGIN @1 DESIGNATED 10 // Correction de la traduction de Baldur's Gate II : Enha
 		SAY NAME2 @240
 	BUT_ONLY_IF_IT_CHANGES
 
-	// Correction du nom car personnage féminin (Mage cagoulée)
+	// Correction du nom car personnage féminin (Magicienne cagoulée)
 	COPY_EXISTING ~MAGE18A.CRE~ ~override~
 				  ~MAGE16C.CRE~ ~override~
 		SAY NAME1 @241
@@ -633,6 +633,112 @@ BEGIN @1 DESIGNATED 10 // Correction de la traduction de Baldur's Gate II : Enha
 				  ~TANTUG02.CRE~ ~override~
 		SAY NAME1 @269
 		SAY NAME2 @269
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom car personnage féminin (Ouvrière)
+	COPY_EXISTING ~WORKER02.CRE~ ~override~
+		SAY NAME1 @270
+		SAY NAME2 @270
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom car personnage féminin (Lieutenante magicienne)
+	COPY_EXISTING ~YAGA02.CRE~ ~override~
+		SAY NAME1 @271
+		SAY NAME2 @271
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom car personnage féminin (Magicienne)
+	COPY_EXISTING ~CUTAMMAG.CRE~ ~override~
+				  ~DGMAG01.CRE~ ~override~
+				  ~FSMAGE01.CRE~ ~override~
+				  ~FSMAGE02.CRE~ ~override~
+				  ~FSMAGE03.CRE~ ~override~
+				  ~FSMAGE04.CRE~ ~override~
+				  ~MAGCLE20.CRE~ ~override~
+				  ~MAGETEST.CRE~ ~override~
+				  ~SARGRD06.CRE~ ~override~
+				  ~TANWIZ02.CRE~ ~override~
+				  ~TOLMAG02.CRE~ ~override~
+		SAY NAME1 @272
+		SAY NAME2 @272
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom car personnage féminin (Magicienne elfe)
+	COPY_EXISTING ~DAELF.CRE~ ~override~
+				  ~DAELF2.CRE~ ~override~
+		SAY NAME1 @273
+		SAY NAME2 @273
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom car personnage féminin (Magicienne de Yaga-Shura)
+	COPY_EXISTING ~YSMAGE02.CRE~ ~override~
+		SAY NAME1 @274
+		SAY NAME2 @274
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom pour coller au lieu (Roturier elfe noir)
+	COPY_EXISTING ~UDCOM01.CRE~ ~override~
+		SAY NAME1 @275
+		SAY NAME2 @275
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom pour coller au lieu (Roturière elfe noire)
+	COPY_EXISTING ~UDCOM02.CRE~ ~override~
+		SAY NAME1 @276
+		SAY NAME2 @276
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom car personnage féminin (Ensorceleuse sharrane)
+	COPY_EXISTING ~ohrshr23.CRE~ ~override~
+		WRITE_LONG 0x08 84585
+		WRITE_LONG 0x0c 84585
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom pour coller au dialogue (Aubergiste)
+	COPY_EXISTING ~VVSTAND2.CRE~ ~override~
+		WRITE_LONG 0x08 12343
+		WRITE_LONG 0x0c 12330
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom pour coller au lieu (Roturier)
+	COPY_EXISTING ~BMTOWN1.CRE~ ~override~
+				  ~BMTOWN2.CRE~ ~override~
+				  ~BMTOWN3.CRE~ ~override~
+				  ~DMTOWN1.CRE~ ~override~
+				  ~DMTOWN2.CRE~ ~override~
+				  ~FFCROWD3.CRE~ ~override~
+				  ~MTOWN1.CRE~ ~override~
+				  ~MTOWN2.CRE~ ~override~
+				  ~MTOWN3.CRE~ ~override~
+				  ~MTOWN4.CRE~ ~override~
+				  ~SLUMM1.CRE~ ~override~
+				  ~SLUMM2.CRE~ ~override~
+				  ~SLUMM3.CRE~ ~override~
+				  ~SLUMM4.CRE~ ~override~
+				  ~VVSTAND1.CRE~ ~override~
+				  ~BDAUD01.CRE~ ~override~
+				  ~WPCUST1.CRE~ ~override~
+		WRITE_LONG 0x08 9429
+		WRITE_LONG 0x0c 9429
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom pour coller au lieu (Roturière)
+	COPY_EXISTING ~BDAUD02.CRE~ ~override~
+				  ~POSTUL3.CRE~ ~override~
+				  ~POSTUL5.CRE~ ~override~
+				  ~SARFEM01.CRE~ ~override~
+				  ~SARFEM02.CRE~ ~override~
+				  ~SARFEM03.CRE~ ~override~
+				  ~SARFEM04.CRE~ ~override~
+				  ~VVSTAND3.CRE~ ~override~
+		WRITE_LONG 0x08 9428
+		WRITE_LONG 0x0c 9428
+	BUT_ONLY_IF_IT_CHANGES
+
+	// Correction du nom pour coller au dialogue (Dame)
+	COPY_EXISTING ~TRFTOW02.CRE~ ~override~
+		WRITE_LONG 0x08 9420
+		WRITE_LONG 0x0c 9421
 	BUT_ONLY_IF_IT_CHANGES
 
 /////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\/////\\\\\

--- a/correctfrbg2ee/francais/correctcreatures.tra
+++ b/correctfrbg2ee/francais/correctcreatures.tra
@@ -130,7 +130,7 @@
 @240 = ~Pleureur~
 
 // (MAGE18A.CRE / MAGE16C.CRE)
-@241 = ~Mage cagoulée~
+@241 = ~Magicienne cagoulée~
 
 // (ohbdanc1.CRE / ohbdanc2.CRE)
 @242 = ~Danseuse~
@@ -215,3 +215,24 @@
 
 // (REBAND04.CRE / TANTUG02.CRE)
 @269 = ~Malfaitrice~
+
+// (WORKER02.CRE)
+@270 = ~Ouvrière~
+
+// (YAGA02.CRE)
+@271 = ~Lieutenante magicienne~
+
+// (CUTAMMAG.CRE / DGMAG01.CRE / FSMAGE01.CRE / FSMAGE02.CRE / FSMAGE03.CRE / FSMAGE04.CRE / MAGCLE20.CRE / MAGETEST.CRE / SARGRD06.CRE / TANWIZ02.CRE / TOLMAG02.CRE)
+@272 = ~Magicienne~
+
+// (DAELF.CRE / DAELF2.CRE)
+@273 = ~Magicienne elfe~
+
+// (YSMAGE02.CRE)
+@274 = ~Magicienne de Yaga-Shura~
+
+// (UDCOM01.CRE)
+@275 = ~Roturier elfe noir~
+
+// (UDCOM02.CRE)
+@276 = ~Roturière elfe noire~

--- a/correctfrbg2ee/francais/soundset.tra
+++ b/correctfrbg2ee/francais/soundset.tra
@@ -66,8 +66,8 @@
 @1069 = ~En effet.~ [Female8i]
 @1070 = ~Voilà qui est fait.~ [Female8j]
 @1071 = ~Certainement.~ [Female8k]
-@1072 = ~~ [Female8l]
-@1073 = ~~ [Female8m]
+@1072 = ~Ouuuh !~ [Female8l]
+@1073 = ~Oooooh ! Ouuuh, ahhhh...~ [Female8m]
 
 @2000 = ~BG1 Homme 1~
 @2001 = ~Crevez tous !~ [Male6a]
@@ -126,5 +126,5 @@
 @2069 = ~Ce sera fait.~ [Male9i]
 @2070 = ~Aucun problème.~ [Male9j]
 @2071 = ~À l'aise.~ [Male9k]
-@2072 = ~~ [Male9l]
-@2073 = ~~ [Male9m]
+@2072 = ~Ah !~ [Male9l]
+@2073 = ~Aaaaah ! Oaah, eugh... euuuhhhh...~ [Male9m]

--- a/correctfrbg2ee/readme/readme-correctfrbg2ee.html
+++ b/correctfrbg2ee/readme/readme-correctfrbg2ee.html
@@ -383,7 +383,7 @@
 				<li style="margin-left:-4%; margin-right:-6%;">Citoyenne (KPFARM02.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Usurière (KPLEND02.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Pleureur (MOURNER5.CRE).</li>
-				<li style="margin-left:-4%; margin-right:-6%;">Mage cagoulée (MAGE18A.CRE, MAGE16C.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Magicienne cagoulée (MAGE18A.CRE, MAGE16C.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Danseuse (ohbdanc1.CRE, ohbdanc2.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Assassine (IRETHF05.CRE, ISHTHF02.CRE, PLASS02.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Soldate de Roenal (KPROEN05.CRE).</li>
@@ -412,6 +412,18 @@
 				<li style="margin-left:-4%; margin-right:-6%;">Cuisinière (SCOOK.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Voyageuse (RERAK03.CRE, RERAK05.CRE, RERAK06.CRE).</li>
 				<li style="margin-left:-4%; margin-right:-6%;">Malfaitrice (REBAND04.CRE, TANTUG02.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Ouvrière (WORKER02.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Lieutenante magicienne (YAGA02.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Magicienne (CUTAMMAG.CRE, DGMAG01.CRE, FSMAGE01.CRE, FSMAGE02.CRE, FSMAGE03.CRE, FSMAGE04.CRE, MAGCLE20.CRE, MAGETEST.CRE, SARGRD06.CRE, TANWIZ02.CRE, TOLMAG02.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Magicienne elfe (DAELF.CRE, DAELF2.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Magicienne de Yaga-Shura (YSMAGE02.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Roturier elfe noir (UDCOM01.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Roturière elfe noire (UDCOM02.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Ensorceleuse sharrane (ohrshr23.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Aubergiste (VVSTAND2.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Roturier (BMTOWN1.CRE, BMTOWN2.CRE, BMTOWN3.CRE, DMTOWN1.CRE, DMTOWN2.CRE, FFCROWD3.CRE, MTOWN1.CRE, MTOWN2.CRE, MTOWN3.CRE, MTOWN4.CRE, SLUMM1.CRE, SLUMM2.CRE, SLUMM3.CRE, SLUMM4.CRE, VVSTAND1.CRE, BDAUD01.CRE, WPCUST1.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Roturière (BDAUD02.CRE, POSTUL3.CRE, POSTUL5.CRE, SARFEM01.CRE, SARFEM02.CRE, SARFEM03.CRE, SARFEM04.CRE, VVSTAND3.CRE).</li>
+				<li style="margin-left:-4%; margin-right:-6%;">Dame (TRFTOW02.CRE).</li>
 				</ul>
 		</ul><br>
 


### PR DESCRIPTION
	- Ouvrière (WORKER02.CRE).
	- Lieutenante magicienne (YAGA02.CRE).
	- Magicienne (CUTAMMAG.CRE, DGMAG01.CRE, FSMAGE01.CRE, FSMAGE02.CRE, FSMAGE03.CRE, FSMAGE04.CRE, MAGCLE20.CRE, MAGETEST.CRE, SARGRD06.CRE, TANWIZ02.CRE, TOLMAG02.CRE).
	- Magicienne elfe (DAELF.CRE, DAELF2.CRE).
	- Magicienne de Yaga-Shura (YSMAGE02.CRE).
	- Roturier elfe noir (UDCOM01.CRE).
	- Roturière elfe noire (UDCOM02.CRE).
	- Ensorceleuse sharrane (ohrshr23.CRE).
	- Aubergiste (VVSTAND2.CRE).
	- Roturier (BMTOWN1.CRE, BMTOWN2.CRE, BMTOWN3.CRE, DMTOWN1.CRE, DMTOWN2.CRE, FFCROWD3.CRE, MTOWN1.CRE, MTOWN2.CRE, MTOWN3.CRE, MTOWN4.CRE, SLUMM1.CRE, SLUMM2.CRE, SLUMM3.CRE, SLUMM4.CRE, VVSTAND1.CRE, BDAUD01.CRE, WPCUST1.CRE).
	- Roturière (BDAUD02.CRE, POSTUL3.CRE, POSTUL5.CRE, SARFEM01.CRE, SARFEM02.CRE, SARFEM03.CRE, SARFEM04.CRE, VVSTAND3.CRE).
	- Dame (TRFTOW02.CRE).